### PR TITLE
Add support for tables

### DIFF
--- a/html_reports/reports.py
+++ b/html_reports/reports.py
@@ -21,7 +21,7 @@ def read_template(uri):
 def transform_markdown(text):
     """ auxiliar function to transform markdown to html """
 
-    return markdown(text, extensions=["fenced_code", "codehilite"])
+    return markdown(text, extensions=["fenced_code", "codehilite", "tables"])
 
 
 class Report:


### PR DESCRIPTION
This allows tables to be entered in markdown which are rendered in HTML

(from the extension list at https://python-markdown.github.io/extensions/, checked locally)