### PR TITLE
Removed easydev dependency to fix the issue with template default path

### DIFF
--- a/html_reports/reports.py
+++ b/html_reports/reports.py
@@ -4,7 +4,7 @@ import os
 from io import BytesIO
 import base64
 
-import easydev
+import importlib
 import matplotlib.pyplot as plt
 from jinja2 import Template
 from markdown import markdown
@@ -124,11 +124,9 @@ class Report:
 
         # If no custom path, use one of the predefined templates
         if template_path is None:
-            relative_uri = f"html_reports/templates/{template_name}.html"
+            pkg_loc = os.path.dirname(importlib.util.find_spec("html_reports").origin)
 
-            template_uri = os.sep.join(
-                [easydev.get_package_location("html_reports")] + relative_uri.split("/")
-            )
+            template_uri = f"{pkg_loc}/templates/{template_name}.html"
 
         # Else, use user template
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 beautifulsoup4
-easydev
 jinja2
 matplotlib
 markdown

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
         "Programming Language :: Python :: 3.6",
     ],
     package_data={"html_reports": ["resources/*"]},
-    install_requires=["beautifulsoup4", "easydev", "jinja2", "matplotlib", "markdown"],
+    install_requires=["beautifulsoup4", "jinja2", "matplotlib", "markdown"],
 )


### PR DESCRIPTION
As described in https://github.com/villoro/html-reports/issues/12, with [easydev](https://pypi.org/project/easydev) v0.12.2 the code used to recover the default template path no longer works. This PR aims to explicitly remove the easydev dependency in favor of the built-in Python package [`importlib`](https://docs.python.org/3/library/importlib.html) to fix the problem.

An alternative and immediate solution may simply require adding the proper constraints for the easydev version (`"easydev<0.12.2"`) both in [`requirements.txt`](https://github.com/villoro/html-reports/blob/master/requirements.txt) and [`setup.py`](https://github.com/villoro/html-reports/blob/master/setup.py).